### PR TITLE
JCN 141 MySQL debe retornar id al insertar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ### Changed
 - `insert` returns ID inserted.
+- `save` returns ID inserted / updated.
 
 ## [1.3.2] - 2019-08-08
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- `insert` returns ID inserted.
+
 ## [1.3.2] - 2019-08-08
 ### Fixed
 - Updated `@janiscommerce/query-builder` version

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ const config = {
 
     - `model`: a Model instance with the *database*, *tables*, *fields*, *joins* and other data.
     - `item`: *type* `OBJECT`,the object to be saved.
-    - **Returns**, `Promise` with `true` if the object was saved correctly.
+    - **Returns**, `ID` of the object inserted / updated.
 
 * `multiInsert(model, items)` **ASYNCHRONOUS**, Performs an Insert of multiple objects. Duplicate Objects updates it.
 
@@ -151,7 +151,7 @@ movieItem = {
 
 try {
     movieResponse = await mysql.insert(movieModel, movieItem);
-    // Response: TRUE
+    // Response: 1
     console.log('Movie Saved'); // Print in Console
 } catch (error) {
     console.log('These Movie can\'t be saved.');
@@ -208,7 +208,7 @@ movieItem = {
 try {
 
     movieResponse = await mysql.save(movieModel, movieItem);
-    // Insert and Response: TRUE
+    // Insert and Response: 2
     console.log('Movie Saved'); // Print in Console
 
 } catch(error) {

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ const config = {
 
     - `model`: a Model instance with the *database*, *tables*, *fields*, *joins* and other data.
     - `item`: *type* `OBJECT`, the object to be inserted.
-    - **Returns**, `boolean` if the object was inserted correctly returns `true`.
+    - **Returns**, `ID` of the object inserted.
 
 * `save(model, item)` **ASYNCHRONOUS**, Saved an individual object in the database. Duplicate Objects updates it.
 

--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -98,8 +98,9 @@ class MySQL {
 			const queryBuilder = new QueryBuilder(this.knex, model);
 			// Insert could response with an Array with 0 value if Primary Key is not AutoIncremental
 			// or Primary Key value if is ID and Integer and AutoIncremental
-			const result = await queryBuilder.insert(item);
-			return !!result;
+			const [result] = await queryBuilder.insert(item);
+
+			return result || item.id;
 
 		} catch(error) {
 			throw new MySQLError(error.message, MySQLError.codes.INVALID_INSERT);

--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -83,7 +83,7 @@ class MySQL {
 	*	Insert an item into the database
 	*	@param {instance} model - Model instance
 	*	@param {object} item - The item to insert
-	*	@returns {Promise<boolean>} True if success
+	*	@returns {Insert} ID
 	*/
 	async insert(model, item) {
 
@@ -112,7 +112,7 @@ class MySQL {
 	 * Save a new items or update it in the SQL database.
 	 * @param {instance} model Model Class Instance
 	 * @param {object} item object to saved
-	 * @returns {Promise<boolean>} True if success
+	 * @returns {Integer} ID
 	 */
 	async save(model, item) {
 
@@ -126,7 +126,8 @@ class MySQL {
 			const queryBuilder = new QueryBuilder(this.knex, model);
 			const [result] = await queryBuilder.save(item);
 
-			return !!result[this.constructor.affectedRows];
+			// If ID is not Auto-Incremental 'insertId0 is 0 when insert. Anything else 'insertId' is ID inserted
+			return result.insertId || item.id;
 
 		} catch(error) {
 			throw new MySQLError(error.message, MySQLError.codes.INVALID_SAVE);

--- a/tests/mysql-test.js
+++ b/tests/mysql-test.js
@@ -65,7 +65,7 @@ describe('MySQL module', function() {
 
 				const result = await mysql.insert(dummyModel, item);
 
-				assert.equal(result, item.id);
+				assert.strictEqual(result, item.id);
 			});
 
 			it('should return ID if try to insert a new Item with Auto-Incremental ID', async function() {
@@ -82,7 +82,7 @@ describe('MySQL module', function() {
 
 				const result = await mysql.insert(dummyModel, item);
 
-				assert.equal(result, itemIdGenerated);
+				assert.strictEqual(result, itemIdGenerated);
 			});
 
 			it('should return ID if try to insert a new Item which has ID with Auto-Incremental ID', async function() {
@@ -98,7 +98,7 @@ describe('MySQL module', function() {
 
 				const result = await mysql.insert(dummyModel, item);
 
-				assert.equal(result, item.id);
+				assert.strictEqual(result, item.id);
 			});
 
 			it('should throw MySqlError if try to insert an item that already exist', async function() {
@@ -113,24 +113,48 @@ describe('MySQL module', function() {
 				await assert.rejects(mysql.insert(dummyModel, item), { code: MySQLError.codes.INVALID_INSERT });
 			});
 
-			it('should return true if try to save a new item', async function() {
+			it('should return ID if try to save a new item with ID no auto-incremental', async function() {
+
+				const item = {
+					id: 2,
+					superhero: 'batman'
+				};
 
 				sandbox.stub(QueryBuilder.prototype, 'save').callsFake(() => {
 					return [{ affectedRows: 1, insertId: 0 }];
 				});
 
-				const result = await mysql.save(dummyModel, {
-					id: 2,
-					superhero: 'batman'
-				});
+				const result = await mysql.save(dummyModel, item);
 
-				assert.equal(result, true);
+				assert.strictEqual(result, item.id);
 			});
 
-			it('should return true if try to save an old item', async function() {
+			it('should return ID if try to save a new item with ID auto-incremental', async function() {
+
+				const itemIDGenerated = 2;
+
+				const item = {
+					superhero: 'batman'
+				};
 
 				sandbox.stub(QueryBuilder.prototype, 'save').callsFake(() => {
-					return [{ affectedRows: 2 }];
+					return [{ affectedRows: 1, insertId: itemIDGenerated }];
+				});
+
+				const result = await mysql.save(dummyModel, item);
+
+				assert.strictEqual(result, itemIDGenerated);
+			});
+
+			it('should return ID if try to save an existing item', async function() {
+
+				const item = {
+					id: 1,
+					superhero: 'hulk'
+				};
+
+				sandbox.stub(QueryBuilder.prototype, 'save').callsFake(() => {
+					return [{ affectedRows: 2, insertId: item.id }];
 				});
 
 				const result = await mysql.save(dummyModel, {
@@ -138,7 +162,7 @@ describe('MySQL module', function() {
 					superhero: 'hulk'
 				});
 
-				assert.equal(result, true);
+				assert.strictEqual(result, item.id);
 			});
 
 
@@ -155,7 +179,7 @@ describe('MySQL module', function() {
 
 				const result = await mysql.update(dummyModel, fields, filters);
 
-				assert.equal(result, 2);
+				assert.strictEqual(result, 2);
 			});
 
 			it('should return 0 if try to update using filters don\'t match any item', async function() {
@@ -171,7 +195,7 @@ describe('MySQL module', function() {
 
 				const result = await mysql.update(dummyModel, fields, filters);
 
-				assert.equal(result, 0);
+				assert.strictEqual(result, 0);
 			});
 
 			it('should return 1 if try to multi-Insert a new Item', async function() {
@@ -186,7 +210,7 @@ describe('MySQL module', function() {
 				}]);
 
 
-				assert.equal(result, 1);
+				assert.strictEqual(result, 1);
 			});
 
 			it('should return the quantity of new items as rows affected if try to multi-Insert new Items', async function() {
@@ -202,7 +226,7 @@ describe('MySQL module', function() {
 				]);
 
 
-				assert.equal(result, 3);
+				assert.strictEqual(result, 3);
 			});
 
 			it('should return the double of quantity of new items as rows affected if try to multi-Insert Items which already exist', async function() {
@@ -217,7 +241,7 @@ describe('MySQL module', function() {
 				]);
 
 
-				assert.equal(result, 4);
+				assert.strictEqual(result, 4);
 			});
 
 		});
@@ -349,7 +373,7 @@ describe('MySQL module', function() {
 			});
 
 			const testParams = (params, expectedParams) => {
-				assert.deepEqual(params, expectedParams, 'shouldn\'t modify ofiginal params');
+				assert.deepStrictEqual(params, expectedParams, 'shouldn\'t modify ofiginal params');
 			};
 
 			it('should return default values getting totals with empty tables', async function() {
@@ -363,7 +387,7 @@ describe('MySQL module', function() {
 					total: 0
 				};
 
-				assert.deepEqual(await mysql.getTotals(dummyModel), totalExpected);
+				assert.deepStrictEqual(await mysql.getTotals(dummyModel), totalExpected);
 			});
 
 			it('Should return empty results and totals with zero values', async function() {
@@ -374,11 +398,11 @@ describe('MySQL module', function() {
 
 				const result = await mysql.get(dummyModel, params);
 
-				assert.deepEqual(result, []);
+				assert.deepStrictEqual(result, []);
 
 				const resultTotals = await mysql.getTotals(dummyModel);
 
-				assert.deepEqual(resultTotals, { total: 0, pages: 0 });
+				assert.deepStrictEqual(resultTotals, { total: 0, pages: 0 });
 
 				testParams(params, {});
 			});
@@ -392,7 +416,7 @@ describe('MySQL module', function() {
 
 				const result = await mysql.get(dummyModel, params);
 
-				assert.deepEqual(result, [{ result: 1 }, { result: 2 }]);
+				assert.deepStrictEqual(result, [{ result: 1 }, { result: 2 }]);
 
 				testParams(params, originalParams);
 
@@ -400,7 +424,7 @@ describe('MySQL module', function() {
 
 				const resultTotals = await mysql.getTotals(dummyModel);
 
-				assert.deepEqual(resultTotals, {
+				assert.deepStrictEqual(resultTotals, {
 					total: 650,
 					page: 1,
 					pageSize: 500,
@@ -417,7 +441,7 @@ describe('MySQL module', function() {
 
 				const result = await mysql.get(dummyModel, params);
 
-				assert.deepEqual(result, [{ result: 1 }, { result: 2 }]);
+				assert.deepStrictEqual(result, [{ result: 1 }, { result: 2 }]);
 
 				testParams(params, originalParams);
 
@@ -425,7 +449,7 @@ describe('MySQL module', function() {
 
 				const resultTotals = await mysql.getTotals(dummyModel);
 
-				assert.deepEqual(resultTotals, {
+				assert.deepStrictEqual(resultTotals, {
 					total: 650,
 					page: 4,
 					pageSize: 10,
@@ -442,7 +466,7 @@ describe('MySQL module', function() {
 
 				const result = await mysql.get(dummyModel, params);
 
-				assert.deepEqual(result, [{ result: 1 }, { result: 2 }]);
+				assert.deepStrictEqual(result, [{ result: 1 }, { result: 2 }]);
 
 				testParams(params, originalParams);
 
@@ -450,7 +474,7 @@ describe('MySQL module', function() {
 
 				const resultTotals = await mysql.getTotals(dummyModel);
 
-				assert.deepEqual(resultTotals, {
+				assert.deepStrictEqual(resultTotals, {
 					total: 650,
 					page: 65,
 					pageSize: 10,
@@ -518,7 +542,7 @@ describe('MySQL module', function() {
 				filters: { id: 1 }
 			});
 
-			assert.equal(results, 1);
+			assert.strictEqual(results, 1);
 		});
 
 		it('should throw MySqlError if can not remove', async function() {

--- a/tests/mysql-test.js
+++ b/tests/mysql-test.js
@@ -52,18 +52,53 @@ describe('MySQL module', function() {
 				sandbox.restore();
 			});
 
-			it('should return true if try to insert a new Item', async function() {
+			it('should return ID if try to insert a new Item with no Auto-Incremental ID', async function() {
 
-				sandbox.stub(QueryBuilder.prototype, 'insert').callsFake(() => {
-					return [0];
-				});
-
-				const result = await mysql.insert(dummyModel, {
+				const item = {
 					id: 1,
 					superhero: 'superman'
+				};
+
+				sandbox.stub(QueryBuilder.prototype, 'insert').callsFake(() => {
+					return [0]; // Knex return this if no auto-incremental ID
 				});
 
-				assert.equal(result, true);
+				const result = await mysql.insert(dummyModel, item);
+
+				assert.equal(result, item.id);
+			});
+
+			it('should return ID if try to insert a new Item with Auto-Incremental ID', async function() {
+
+				const itemIdGenerated = 10;
+
+				const item = {
+					superhero: 'supergirl'
+				};
+
+				sandbox.stub(QueryBuilder.prototype, 'insert').callsFake(() => {
+					return [itemIdGenerated]; // Knex return this if no auto-incremental ID
+				});
+
+				const result = await mysql.insert(dummyModel, item);
+
+				assert.equal(result, itemIdGenerated);
+			});
+
+			it('should return ID if try to insert a new Item which has ID with Auto-Incremental ID', async function() {
+
+				const item = {
+					id: 20,
+					superhero: 'Wolverine'
+				};
+
+				sandbox.stub(QueryBuilder.prototype, 'insert').callsFake(() => {
+					return [item.id]; // Knex return this if no auto-incremental ID
+				});
+
+				const result = await mysql.insert(dummyModel, item);
+
+				assert.equal(result, item.id);
 			});
 
 			it('should throw MySqlError if try to insert an item that already exist', async function() {


### PR DESCRIPTION
**JCN 141-MySQL-debe-retornar-id-al-insertar**
JCN 141 MySQL debe retornar id al insertar

**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-141

**DESCRIPCIÓN DEL REQUERIMIENTO**
2.1 - Se requiere actualizar el paquete de **MySQL**
2.2 - Se requiere que al insertar un registro devuelva la _ID_ del mismo en la base de datos.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se desarrollo el paquete con los requerimientos solicitados. Y además se cambió `Save`. No pude lograr que el `MultiInsert` devolviera los ID, dado que solo en el mejor caso devuelve solo un ID, y se modifica algúnos elementos no indica cuales.